### PR TITLE
fixed NPE bug

### DIFF
--- a/promise/src/main/java/tv/loilo/promise/NullDeferredException.java
+++ b/promise/src/main/java/tv/loilo/promise/NullDeferredException.java
@@ -1,0 +1,10 @@
+package tv.loilo.promise;
+
+/**
+ * An Exception that Defer callback returned null.
+ */
+public class NullDeferredException extends RuntimeException {
+    public NullDeferredException(String detailMessage) {
+        super(detailMessage);
+    }
+}

--- a/promise/src/main/java/tv/loilo/promise/Promises.java
+++ b/promise/src/main/java/tv/loilo/promise/Promises.java
@@ -325,7 +325,7 @@ public final class Promises {
 
                                 scope.attach(new ArrayCloseableStack());
 
-                                Deferred<TOut> deferred;
+                                Deferred<TOut> deferred = null;
                                 if (params.getCancelToken().isCanceled()) {
                                     deferred = Defer.cancel();
                                 } else {
@@ -338,6 +338,10 @@ public final class Promises {
                                         deferred = Defer.cancel();
                                     } catch (final Exception e) {
                                         deferred = Defer.fail(e);
+                                    } finally {
+                                        if (deferred == null) {
+                                            deferred = Defer.fail(new NullDeferredException("RepeatCallback returned null"));
+                                        }
                                     }
                                 }
 
@@ -585,7 +589,7 @@ public final class Promises {
 
         @Override
         public void execute(final Result<TIn> input, final CancelToken cancelToken, final CloseableStack scope, final Object tag) {
-            Deferred<TOut> deferred;
+            Deferred<TOut> deferred = null;
             try {
                 deferred = mThenCallback.run(new ThenParams<>(input, scope, tag));
             } catch (final InterruptedException e) {
@@ -595,6 +599,10 @@ public final class Promises {
                 deferred = Defer.cancel();
             } catch (final Exception e) {
                 deferred = Defer.fail(e);
+            } finally {
+                if (deferred == null) {
+                    deferred = Defer.fail(new NullDeferredException("ThenCallback returned null"));
+                }
             }
 
             final Result<TOut> output = Results.exchangeCancelToken(deferred.getResult(), cancelToken);
@@ -792,7 +800,7 @@ public final class Promises {
         @Override
         public void execute(final CancelToken cancelToken, final CloseableStack scope, final Object tag) {
 
-            Deferred<TOut> handle;
+            Deferred<TOut> handle = null;
             //Do not call the initial callback when Promise was already canceled.
             if (cancelToken.isCanceled()) {
                 handle = Defer.cancel();
@@ -806,6 +814,10 @@ public final class Promises {
                     handle = Defer.cancel();
                 } catch (final Exception e) {
                     handle = Defer.fail(e);
+                } finally {
+                    if (handle == null) {
+                        handle = Defer.fail(new NullDeferredException("WhenCallback returned null"));
+                    }
                 }
             }
 


### PR DESCRIPTION
Fixed issue that NPE will occur if When, Then, Repeat callback retuned null or something wrong will happen.
In some cases, promise created by PromiseLoader will throw NullPointerException at code like below:

```
final Result<TOut> result = Results.exchangeCancelToken(deferred.getResult(), cancelToken);
```

The reason why does it happen is `deferred` returned by callback is null (in my case, I didn't return null)
I couldn't figure out what is the fact but apply the patch...
